### PR TITLE
Fix dependency: move "typescript" to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "repository": "https://github.com/kirisaki/fn-mt",
   "author": "Akihito KIRISAKI <kirisaki@klaraworks.net>",
   "license": "BSD-3-Clause",
-  "dependencies": {
+  "devDependencies": {
     "typescript": "^3.8.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
   "license": "BSD-3-Clause",
   "devDependencies": {
     "typescript": "^3.8.3"
+  },
+  "scripts": {
+    "build": "tsc"
   }
 }


### PR DESCRIPTION
typescript が dependencies に入っていたので devDependencies に移動した。ついでに `yarn build` でビルドするよう npm scripts を追加した。