### PR TITLE
add sideEffects hint to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "functional implementation of Mersenne Twister",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Marks this library as side-effect-free, so that Webpack and other bundlers will know that parts of it can be tree-shaken if not imported.

https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free